### PR TITLE
Added frogcomposband package build

### DIFF
--- a/packages/frogcomposband/LICENSE
+++ b/packages/frogcomposband/LICENSE
@@ -1,0 +1,3 @@
+Copyright (c) 1997 Ben Harrison, James E. Wilson, Robert A. Koeneke
+
+This software may be copied and distributed for educational, research, and not for profit purposes provided that this copyright and statement are included in all such copies. Other copyrights may also apply.

--- a/packages/frogcomposband/autoconf.h.in.patch
+++ b/packages/frogcomposband/autoconf.h.in.patch
@@ -1,0 +1,12 @@
+diff --git a/src/autoconf.h.in b/src/autoconf.h.in
+index 3ea96d74..069e6452 100644
+--- a/src/autoconf.h.in
++++ b/src/autoconf.h.in
+@@ -20,7 +20,6 @@
+ #undef HAVE_FCNTL_H
+ 
+ /* Define to 1 if you have the `fdopen' function. */
+-#undef HAVE_FDOPEN
+ 
+ /* Define to 1 if you have the <inttypes.h> header file. */
+ #undef HAVE_INTTYPES_H

--- a/packages/frogcomposband/build.sh
+++ b/packages/frogcomposband/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/sulkasormi/frogcomposband/
 TERMUX_PKG_DESCRIPTION="Open world Angband variant with many additions"
-TERMUX_PKG_LICENSE="Angband"
+TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_SRCURL=https://github.com/sulkasormi/frogcomposband.git
 TERMUX_PKG_VERSION=7.1.salmiak
 TERMUX_PKG_DEPENDS="ncurses"
@@ -15,4 +15,9 @@ termux_step_pre_configure () {
 
 termux_step_post_make_install () {
 	rm -Rf $TERMUX_PREFIX/share/frogcomposband/fonts
+}
+
+termux_step_install_license() {
+	install -Dm600 $TERMUX_PKG_BUILDER_DIR/LICENSE \
+		$TERMUX_PREFIX/share/doc/frogcomposband/LICENSE
 }

--- a/packages/frogcomposband/build.sh
+++ b/packages/frogcomposband/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/sulkasormi/frogcomposband/
+TERMUX_PKG_DESCRIPTION="Open world Angband variant with many additions"
+TERMUX_PKG_LICENSE="Angband"
+TERMUX_PKG_SRCURL=https://github.com/sulkasormi/frogcomposband.git
+TERMUX_PKG_VERSION=7.1.salmiak
+TERMUX_PKG_DEPENDS="ncurses"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-x11 --bindir=$TERMUX_PREFIX/bin --sysconfdir=$TERMUX_PREFIX/share/frogcomposband"
+TERMUX_PKG_RM_AFTER_INSTALL="share/angband/xtra share/angband/icons"
+
+termux_step_pre_configure () {
+	./autogen.sh
+	perl -p -i -e 's|ncursesw5-config|ncursesw6-config|g' configure
+}
+
+termux_step_post_make_install () {
+	rm -Rf $TERMUX_PREFIX/share/frogcomposband/fonts
+}

--- a/packages/frogcomposband/h-config.h.patch
+++ b/packages/frogcomposband/h-config.h.patch
@@ -1,0 +1,14 @@
+diff --git a/src/h-config.h b/src/h-config.h
+index b6cf6081..44b8f240 100644
+--- a/src/h-config.h
++++ b/src/h-config.h
+@@ -207,7 +207,8 @@
+  */
+ #if !defined(MACINTOSH) && !defined(WINDOWS) && \
+   !defined(MSDOS) && !defined(USE_EMX) && !defined(MACH_O_CARBON) &&	\
+-    !defined(AMIGA) && !defined(ACORN) && !defined(VM)
++    !defined(AMIGA) && !defined(ACORN) && !defined(VM) && \
++    !defined(__ANDROID__)
+ # define SET_UID
+ #endif
+ 

--- a/packages/frogcomposband/util.c.patch
+++ b/packages/frogcomposband/util.c.patch
@@ -1,0 +1,22 @@
+diff --git a/src/util.c b/src/util.c
+index dcfebf9c..977611c6 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -977,7 +977,7 @@ errr fd_read(int fd, char *buf, huge n)
+     while (n >= 16384)
+     {
+         /* Read a piece */
+-        if (_read(fd, buf, 16384) != 16384) return (1);
++        if (read(fd, buf, 16384) != 16384) return (1);
+ 
+         /* Shorten the task */
+         buf += 16384;
+@@ -1010,7 +1010,7 @@ errr fd_write(int fd, cptr buf, huge n)
+     while (n >= 16384)
+     {
+         /* Write a piece */
+-        if (_write(fd, buf, 16384) != 16384) return (1);
++        if (write(fd, buf, 16384) != 16384) return (1);
+ 
+         /* Shorten the task */
+         buf += 16384;


### PR DESCRIPTION
I've managed to get several roguelikes to build and run on Termux, and after writing a [big 'ol post](https://archenoth.com/tech/2020/05/29/Roguelikes-in-Termux.html) about doing that, and after helping quite a few people to get them up and running, I figured that I might as well contribute to the repos itself!

This is the first of several packages I plan on making, though I wanted to make sure everything is on the up and up contribution-wise before I build the scripts for the other ones. ^^

The game itself is FrogComposband, which is one of the most popular bands out there currently, which features an overworld, a *lot* of quests, and is one of the most played on [angband.live](https://angband.live) currently.

![A screenshot of the FrogComposband overworld](https://user-images.githubusercontent.com/1385527/90836081-b213aa00-e30b-11ea-83bc-b3e926454bc2.png)
